### PR TITLE
Fix Shynet URL to use TLS

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -63,12 +63,12 @@
   <body>
     <noscript>
       <img
-        src="http://shynet.carletoncomputersciencesociety.ca/ingress/9854bb91-6c3f-457e-a875-81af33ce0970/pixel.gif"
+        src="https://shynet.carletoncomputersciencesociety.ca/ingress/9854bb91-6c3f-457e-a875-81af33ce0970/pixel.gif"
       />
     </noscript>
     <script
       defer
-      src="http://shynet.carletoncomputersciencesociety.ca/ingress/9854bb91-6c3f-457e-a875-81af33ce0970/script.js"
+      src="https://shynet.carletoncomputersciencesociety.ca/ingress/9854bb91-6c3f-457e-a875-81af33ce0970/script.js"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
Chrome isn't able to send telemetry since the URL isn't HTTPS