### PR TITLE
Created Prototype guides app

### DIFF
--- a/app/src/apps/Guides/Guide.astro
+++ b/app/src/apps/Guides/Guide.astro
@@ -1,12 +1,12 @@
 ---
-    const { Content, frontmatter } = Astro.props.mdx; 
+const { Content, frontmatter } = Astro.props.mdx;
 ---
 
 <div>
-    <h1>{frontmatter.title}</h1>
-    <h2>Authored by: {frontmatter.author}</h2>
-    <h3>Last updated on: {frontmatter.last_updated}</h3>
+  <h1>{frontmatter.title}</h1>
+  <h2>Authored by: {frontmatter.author}</h2>
+  <h3>Last updated on: {frontmatter.last_updated}</h3>
 </div>
 <div>
-    <Content />
+  <Content />
 </div>

--- a/app/src/apps/Guides/Guide.astro
+++ b/app/src/apps/Guides/Guide.astro
@@ -1,1 +1,12 @@
-<!-- Please create a component that receives markdown file or markdown text and renders is -->
+---
+    const { Content, frontmatter } = Astro.props.mdx; 
+---
+
+<div>
+    <h1>{frontmatter.title}</h1>
+    <h2>Authored by: {frontmatter.author}</h2>
+    <h3>Last updated on: {frontmatter.last_updated}</h3>
+</div>
+<div>
+    <Content />
+</div>

--- a/app/src/data/guides/comp2804/test.md
+++ b/app/src/data/guides/comp2804/test.md
@@ -229,7 +229,7 @@ to be indented _twice_ -- 8 spaces or two tabs:
 
 - A list item with a code block:
 
-      <code goes here>
+      <!--code goes here (this causes an error when parsed as mdx)-->
 
 ### Code Blocks
 


### PR DESCRIPTION
Astro uses mdast-util-mdx-jsx to parse markdown as mdx and converts it into jsx. This causes an error on line 232 in test.md since "\<code goes here\>" is read as an unclosed "\<code\>" tag rather than a code box.